### PR TITLE
Fix: remove invalid "imports" alias and add private: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "license": "GPL-3.0",
   "module": "./src/index.ts",
   "type": "module",
-  "imports": {
-    "@/*": "./src/*"
-  },
+  "private": true,
   "scripts": {
     "format": "prettier --write \"src/**/*.ts\"",
     "deploy": "bun .",


### PR DESCRIPTION
This PR removes the `"imports"` field from `package.json` because it used the `@/` alias, which is not allowed according to the Node.js specification for `"imports"`. Only aliases starting with `#` are permitted.

Additionally, `"private": true` is added to `package.json` to prevent accidental publishing to npm, since this project is an application and not a distributable library.

---

**References:**

* Official Node.js documentation on `"imports"`:
  [https://nodejs.org/api/packages.html#imports](https://nodejs.org/api/packages.html#imports)